### PR TITLE
fix: README badge formatting — add missing newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # WhiteList
 
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)a open source DApp white list for all wallets with sustainable maintaince by community.
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+a open source DApp white list for all wallets with sustainable maintaince by community.
 
 1. Formate
 jason formate like this:


### PR DESCRIPTION
Fix badge and text concatenated on same line. Adds blank line after license badge.